### PR TITLE
Fix three code bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
 	<artifactId>code-style</artifactId>
 	<version>2.0.1</version>
 	<name>${project.artifactId}</name>
-	<description>bytesgo parent</description>
-	<url>https://github.com/${github.org}/${github.repo}.git</url>
+	<description>Code style and Checkstyle configuration for BytesGo projects</description>
+	<url>https://github.com/${github.org}/${github.repo}</url>
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
@@ -38,19 +38,18 @@
 		</contributor>
 	</contributors>
 	<scm>
-		<connection>scm:git:git@github.com:${github.org}/${github.repo}.git</connection>
-		<developerConnection>
-			scm:git:git@github.com:${github.org}/${github.repo}.git</developerConnection>
+		<connection>scm:git:https://github.com/${github.org}/${github.repo}.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/${github.org}/${github.repo}.git</developerConnection>
 		<tag>HEAD</tag>
-		<url>git@github.com:${github.org}/${github.repo}.git</url>
+		<url>https://github.com/${github.org}/${github.repo}</url>
 	</scm>
 	<issueManagement>
 		<system>github-issue</system>
 		<url>https://github.com/${github.org}/${github.repo}/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>travis-ci</system>
-		<url>https://travis-ci.org/${github.org}/${github.repo}</url>
+		<system>GitHub Actions</system>
+		<url>https://github.com/${github.org}/${github.repo}/actions</url>
 	</ciManagement>
 
 	<properties>

--- a/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.0//EN"
-    "http://www.sparrowzoo.com/dtds/suppressions_1_0.dtd">
+    "https://checkstyle.org/dtds/suppressions_1_0.dtd">
 
 <suppressions>
   <suppress checks="RegexpSingleline"

--- a/src/main/resources/codestyle/eclipse-java-style.xml
+++ b/src/main/resources/codestyle/eclipse-java-style.xml
@@ -61,7 +61,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16" />
-		<setting id="org.eclipse.jdt.core.compiler.source" value="1.7" />
+		<setting id="org.eclipse.jdt.core.compiler.source" value="1.8" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent"
 			value="16|4|48" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert" />
@@ -208,7 +208,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585" />
-		<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7" />
+		<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8" />
 		<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression"
 			value="do not insert" />
@@ -296,7 +296,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert" />
-		<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7" />
+		<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80" />
 		<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16" />


### PR DESCRIPTION
Improve security, metadata correctness, and tooling consistency by updating an insecure DTD, correcting `pom.xml` URLs/SCM, and aligning Eclipse compiler levels.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d101fbc-ef93-4ddf-b47d-6af0eba9a72e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d101fbc-ef93-4ddf-b47d-6af0eba9a72e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

